### PR TITLE
Fixes #3: Migrated from MooseX::AttributeHelpers to native Moose traits

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -37,7 +37,6 @@ my %WriteMakefileArgs = (
     "IO::File" => 0,
     "IO::String" => 0,
     "Moose" => "2.0201",
-    "MooseX::AttributeHelpers" => "0.08",
     "MooseX::MultiInitArg" => 0,
     "Net::Stomp" => 0,
     "POE" => "0.38",

--- a/dist.ini
+++ b/dist.ini
@@ -23,7 +23,6 @@ Heap::Fibonacci             = 0.80
 IO::File                    = 0
 IO::String                  = 0
 Moose                       = 2.0201
-MooseX::AttributeHelpers    = 0.08
 MooseX::MultiInitArg        = 0
 Net::Stomp                  = 0
 POE                         = 0.38

--- a/lib/POE/Component/MessageQueue.pm
+++ b/lib/POE/Component/MessageQueue.pm
@@ -73,18 +73,28 @@ has storage => (
 );
 
 has clients => (
-	metaclass => 'Collection::Hash',
 	isa       => 'HashRef[POE::Component::MessageQueue::Client]',
 	default   => sub { {} },
-	provides  => {
-		'get'    => 'get_client',
-		'delete' => 'remove_client',
-		'set'    => 'set_client',
-		'keys'   => 'all_client_ids',
+	traits  => ['Hash'],
+	handles => {
+		'get_client'     => 'get',
+		'remove_client'  => 'delete',
+		'set_client'     => 'set',
+		'all_client_ids' => 'keys',
 	}
 );
 
-has shutdown_count => (metaclass => 'Counter');
+has shutdown_count => (
+	is      => 'ro',
+	isa     => 'Num',
+	default => 0,
+	traits  => ['Counter'],
+	handles => {
+		'inc_shutdown_count'   => 'inc',
+		'dec_shutdown_count'   => 'dec',
+		'reset_shutdown_count' => 'reset',
+	}
+);
 
 has message_class => (
 	is      => 'ro',
@@ -127,24 +137,24 @@ before remove_client => sub {
 };
 	
 has destinations => (
-	metaclass => 'Collection::Hash',
-	isa       => 'HashRef[POE::Component::MessageQueue::Destination]',
-	default   => sub { {} },
-	provides  => {
-		'get'    => 'get_destination',
-		'set'    => 'set_destination',
-		'values' => 'all_destinations',
+	isa     => 'HashRef[POE::Component::MessageQueue::Destination]',
+	default => sub { {} },
+	traits  => ['Hash'],
+	handles => {
+		'get_destination'  => 'get',
+		'set_destination'  => 'set',
+		'all_destinations' => 'values',
 	}
 );
 
 has owners => (
-	metaclass => 'Collection::Hash',
-	isa       => 'HashRef[POE::Component::MessageQueue::Subscription]',
-	default   => sub { {} },
-	provides  => {
-		'get'    => 'get_owner',
-		'set'    => 'set_owner',
-		'delete' => 'delete_owner',
+	isa     => 'HashRef[POE::Component::MessageQueue::Subscription]',
+	default => sub { {} },
+	traits  => ['Hash'],
+	handles => {
+		'get_owner'    => 'get',
+		'set_owner'    => 'set',
+		'delete_owner' => 'delete',
 	},
 );
 

--- a/lib/POE/Component/MessageQueue/Client.pm
+++ b/lib/POE/Component/MessageQueue/Client.pm
@@ -17,20 +17,19 @@
 
 package POE::Component::MessageQueue::Client;
 use Moose;
-use MooseX::AttributeHelpers;
 use POE::Component::MessageQueue::Subscription;
 use POE::Kernel;
 
 has subscriptions => (
-	metaclass => 'Collection::Hash',
 	is => 'ro',
 	isa => 'HashRef[POE::Component::MessageQueue::Subscription]',
 	default => sub { {} },
-	provides => {
-		'set'    => 'set_subscription',
-		'get'    => 'get_subscription',
-		'values' => 'all_subscriptions',
-		'delete' => 'delete_subscription',
+	traits  => ['Hash'],
+	handles => {
+		'set_subscription'    => 'set',
+		'get_subscription'    => 'get',
+		'all_subscriptions'   => 'values',
+		'delete_subscription' => 'delete',
 	},
 );
 

--- a/lib/POE/Component/MessageQueue/Destination.pm
+++ b/lib/POE/Component/MessageQueue/Destination.pm
@@ -18,8 +18,6 @@
 package POE::Component::MessageQueue::Destination;
 use Moose::Role;
 
-use MooseX::AttributeHelpers;
-
 has parent => (
 	is       => 'ro',
 	required => 1,
@@ -27,15 +25,15 @@ has parent => (
 );
 
 has subscriptions => (
-	metaclass => 'Collection::Hash',
-	is        => 'rw',
-	isa       => 'HashRef[POE::Component::MessageQueue::Subscription]',
-	default   => sub { {} },
-	provides  => {
-		'set'    => 'set_subscription',
-		'get'    => 'get_subscription',
-		'delete' => 'delete_subscription',
-		'values' => 'all_subscriptions',
+	is       => 'rw',
+	isa      => 'HashRef[POE::Component::MessageQueue::Subscription]',
+	default  => sub { {} },
+	traits   => ['Hash'],
+	handles  => {
+		'set_subscription'    => 'set',
+		'get_subscription'    => 'get',
+		'delete_subscription' => 'delete',
+		'all_subscriptions'   => 'values',
 	},
 );
 

--- a/lib/POE/Component/MessageQueue/IDGenerator/SimpleInt.pm
+++ b/lib/POE/Component/MessageQueue/IDGenerator/SimpleInt.pm
@@ -17,7 +17,6 @@
 
 package POE::Component::MessageQueue::IDGenerator::SimpleInt;
 use Moose;
-use MooseX::AttributeHelpers;
 with qw(POE::Component::MessageQueue::IDGenerator);
 
 has 'filename' => (
@@ -27,8 +26,15 @@ has 'filename' => (
 );
 
 has 'last_id' => (
-	metaclass => 'Counter',
-	is        => 'rw',
+	is      => 'rw',
+	isa     => 'Num',
+	default => 0,
+	traits  => ['Counter'],
+	handles => {
+		'inc_last_id'   => 'inc',
+		'dec_last_id'   => 'dec',
+		'reset_last_id' => 'reset',
+	}
 );
 
 sub BUILD

--- a/lib/POE/Component/MessageQueue/Queue.pm
+++ b/lib/POE/Component/MessageQueue/Queue.pm
@@ -20,7 +20,6 @@ package POE::Component::MessageQueue::Queue;
 use POE;
 use POE::Session;
 use Moose;
-use MooseX::AttributeHelpers;
 
 with qw(POE::Component::MessageQueue::Destination);
 
@@ -32,14 +31,14 @@ flag 'shutting_down';
 sub stash {
 	my $n = $_[0];
 	has $n => (
-		metaclass => 'Collection::Hash',
-		is        => 'rw',
-		isa       => 'HashRef',
-    default   => sub { {} },
-		provides  => {
-			'set'    => "set_$n",
-			'delete' => "del_$n",
-			'keys'   => "${n}_keys",
+		is      => 'rw',
+		isa     => 'HashRef',
+		default => sub { {} },
+		traits  => ['Hash'],
+		handles => {
+			"set_$n"    => 'set',
+			"del_$n"    => 'delete',
+			"${n}_keys" => 'keys',
 		}
 	);
 }

--- a/lib/POE/Component/MessageQueue/Storage/Complex.pm
+++ b/lib/POE/Component/MessageQueue/Storage/Complex.pm
@@ -36,7 +36,6 @@ sub cmp
 
 package POE::Component::MessageQueue::Storage::Complex;
 use Moose;
-use MooseX::AttributeHelpers;
 with qw(POE::Component::MessageQueue::Storage::Double);
 
 use POE;
@@ -63,13 +62,13 @@ has alias => (
 );
 
 has front_size => (
-	metaclass => 'Number',
-	is        => 'rw',
-	isa       => 'Int',
-	default   => 0,
-	provides  => {
-		'add' => 'more_front',
-		'sub' => 'less_front',
+	is      => 'rw',
+	isa     => 'Int',
+	default => 0,
+	traits  => ['Number'],
+	handles => {
+		'more_front' => 'add',
+		'less_front' => 'sub',
 	},
 );
 
@@ -80,30 +79,30 @@ has front_max => (
 );
 
 has front_expirations => (
-	metaclass => 'Collection::Hash',
-	is        => 'ro', 
-	isa       => 'HashRef[Num]',
-	default   => sub { {} },
-	provides  => {
-		'set'    => 'expire_from_front',
-		'delete' => 'delete_front_expiration',
-		'clear'  => 'clear_front_expirations',
-		'count'  => 'count_front_expirations',
-		'kv'     => 'front_expiration_pairs',
+	is      => 'ro', 
+	isa     => 'HashRef[Num]',
+	default => sub { {} },
+	traits  => ['Hash'],
+	handles => {
+		'expire_from_front'       => 'set',
+		'delete_front_expiration' => 'delete',
+		'clear_front_expirations' => 'clear',
+		'count_front_expirations' => 'count',
+		'front_expiration_pairs'  => 'kv',
 	},	
 );
 
 has nonpersistent_expirations => (
-	metaclass => 'Collection::Hash',
 	is => 'ro',
 	isa => 'HashRef',
 	default => sub { {} },
-	provides => {
-		'set'    => 'expire_nonpersistent',
-		'delete' => 'delete_nonpersistent_expiration',
-		'clear'  => 'clear_nonpersistent_expirations',
-		'count'  => 'count_nonpersistent_expirations',
-		'kv'     => 'nonpersistent_expiration_pairs',
+	traits  => ['Hash'],
+	handles => {
+		'expire_nonpersistent'            => 'set',
+		'delete_nonpersistent_expiration' => 'delete',
+		'clear_nonpersistent_expirations' => 'clear',
+		'count_nonpersistent_expirations' => 'count',
+		'nonpersistent_expiration_pairs'  => 'kv',
 	},
 );
 
@@ -115,15 +114,15 @@ sub count_expirations
 }
 
 has idle_hash => (
-	metaclass => 'Collection::Hash',
 	is => 'ro',
 	isa => 'HashRef',
 	default   => sub { {} },
-	provides  => {
-		'set'    => '_hashset_idle',
-		'get'    => 'get_idle',
-		'delete' => 'delete_idle',
-		'clear'  => 'clear_idle',
+	traits  => ['Hash'],
+	handles => {
+		'_hashset_idle' => 'set',
+		'get_idle'      => 'get',
+		'delete_idle'   => 'delete',
+		'clear_idle'    => 'clear',
 	},
 );
 

--- a/lib/POE/Component/MessageQueue/Storage/Double.pm
+++ b/lib/POE/Component/MessageQueue/Storage/Double.pm
@@ -17,7 +17,6 @@
 
 package POE::Component::MessageQueue::Storage::Double;
 use Moose::Role;
-use MooseX::AttributeHelpers;
 use MooseX::MultiInitArg;
 
 # These guys just call a method on both front and back stores and have a
@@ -64,16 +63,16 @@ has back => (
 # Any true value for a given ID means the message is in the front store.
 # (value may be useful data, like message size)
 has front_info => (
-	metaclass => 'Collection::Hash',
 	is => 'ro',
 	isa => 'HashRef',
 	default => sub { {} },
-	provides => {
-		'exists' => 'in_front',
-		'get'    => 'get_front',
-		'set'    => 'set_front',
- 		'clear'  => 'clear_front',
-		'delete' => 'delete_front',
+	traits  => ['Hash'],
+	handles => {
+		'in_front'     => 'exists',
+		'get_front'    => 'get',
+		'set_front'    => 'set',
+		'clear_front'  => 'clear',
+		'delete_front' => 'delete',
 	},
 );
 

--- a/lib/POE/Component/MessageQueue/Storage/Throttled.pm
+++ b/lib/POE/Component/MessageQueue/Storage/Throttled.pm
@@ -17,7 +17,6 @@
 
 package POE::Component::MessageQueue::Storage::Throttled;
 use Moose;
-use MooseX::AttributeHelpers;
 use POE;
 
 with qw(POE::Component::MessageQueue::Storage::Double);
@@ -28,8 +27,29 @@ has throttle_max => (
 	default  => 2,
 );
 
-has sent => (metaclass => 'Counter');
-has throttle_count => (metaclass => 'Counter');
+has sent => (
+	is      => 'ro',
+	isa     => 'Num',
+	default => 0,
+	traits  => ['Counter'],
+	handles => {
+		'inc_sent'   => 'inc',
+		'dec_sent'   => 'dec',
+		'reset_sent' => 'reset',
+	}
+);
+
+has throttle_count => (
+	is      => 'ro',
+	isa     => 'Num',
+	default => 0,
+	traits  => ['Counter'],
+	handles => {
+		'inc_throttle_count'   => 'inc',
+		'dec_throttle_count'   => 'dec',
+		'reset_throttle_count' => 'reset',
+	}
+);
 
 has shutdown_callback => (
 	is        => 'rw',


### PR DESCRIPTION
Because MooseX::AttributeHelpers is deprecated.
Thanks for pointing it out Karen Etheridge.
