### PR TITLE
Test fixes

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -51,6 +51,7 @@ my %WriteMakefileArgs = (
     "File::Spec" => 0,
     "IO::Handle" => 0,
     "IPC::Open3" => 0,
+    "Net::EmptyPort" => 0,
     "Test::More" => 0
   },
   "VERSION" => "0.3003",

--- a/dist.ini
+++ b/dist.ini
@@ -24,6 +24,7 @@ IO::File                    = 0
 IO::String                  = 0
 Moose                       = 2.0201
 MooseX::MultiInitArg        = 0
+Net::EmptyPort              = 0
 Net::Stomp                  = 0
 POE                         = 0.38
 POE::Component::Generic     = 0.1001

--- a/t/05_storage_api.t
+++ b/t/05_storage_api.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Net::EmptyPort qw(empty_port);
 
 BEGIN {
     if ($^O eq 'MSWin32') {
@@ -37,9 +38,10 @@ END {
 	rmtree(DATA_DIR);	
 }
 
+my $port = empty_port();
 my $remote = start_fork(sub {
 	use POE::Component::MessageQueue::Storage::Remote::Server;
-	POE::Component::MessageQueue::Storage::Remote::Server->new(port => 9321);
+	POE::Component::MessageQueue::Storage::Remote::Server->new(port => $port);
 });
 ok($remote, "Remote storage engine started.");
 
@@ -297,7 +299,7 @@ sub engine_loop {
 	mkpath(DATA_DIR);
 	make_db();
 
-	my $storage = make_engine($name);
+	my $storage = make_engine($name, { server_port => $port });
 	my $clones = [values %messages];
 
 	store_loop($storage, $clones, sub {

--- a/t/05_storage_api.t
+++ b/t/05_storage_api.t
@@ -64,8 +64,8 @@ sub message_is {
 	if(ref $one ne 'POE::Component::MessageQueue::Message') {
 		return diag "message_is called with non-message argument: ".Dump($one);
 	}
-	return ok($one->equals($two), $name) or
-	       diag("got: ", Dump($two), "\nexpected:", Dump($one), "\n");
+	return (ok($one->equals($two), $name) or
+	        diag("got: ", Dump($two), "\nexpected:", Dump($one), "\n"));
 }
 
 sub run_in_order

--- a/t/lib/POE/Component/MessageQueue/Test/EngineMaker.pm
+++ b/t/lib/POE/Component/MessageQueue/Test/EngineMaker.pm
@@ -76,7 +76,7 @@ my %engines = (
 	},
 	Remote     => {
 		args    => sub {(
-			servers => [{host => 'localhost', port => 9321}],
+			servers => [{host => 'localhost'}], # port is filled in during make_engine
 		)},
 	},
 	BigMemory => {},
@@ -91,7 +91,13 @@ sub make_engine {
 	my $eargs = $engines{$name}->{args} || sub {};
 	my %args = $eargs->();
 	if (defined $extra) {
+	        my $server_port = delete $extra->{server_port};
 		%args = ( %args, %$extra );
+		if ($server_port and $args{servers}) {
+			foreach my $server ( @{$args{servers}} ) {
+				$server->{port} //= $server_port;
+			}
+		}
 	}
 	return engine_package($name)->new(%args,
 		logger => POE::Component::MessageQueue::Logger->new(level=>LOG_LEVEL),


### PR DESCRIPTION
I'm taking part in the 2017 CPAN Pull Request Challenge and my May assignment is POE-Component-MessageQueue.

I saw that some CPANTS test runs were failing on 05_storage_api.t because the port configured in the test is already in use on the test machine. I've fixed this.

I've also fixed a perl diagnostic warning which was being emitted during each run of 05_storage_api.t.

I hope these are useful.

All the best
Michael